### PR TITLE
既存の離婚協議書はなぜ必要かを/divorce/内の該当ページにリダイレクトさせた。

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -14,3 +14,5 @@ RewriteCond %{HTTP_HOST} ^(www\.)?a-dreamlaw\.sakura\.ne\.jp$ [NC]
 RewriteRule .* http://a-dreamlaw.com%{REQUEST_URI} [R=301,L]
 
 Redirect 301 /business/divorce/type/separation.html /divorce/contents/separate.html
+
+Redirect 301 /fee/why/kyougisyo.html /divorce/contents/why-need-kyougisyo.html


### PR DESCRIPTION
既存の離婚協議書はなぜ必要かを/divorce/内の該当ページにリダイレクトさせた。