### PR TITLE
Correct global nav

### DIFF
--- a/common/css/base.css
+++ b/common/css/base.css
@@ -469,6 +469,9 @@ header{
 		border: 2px solid #000;
 	}
 }
+#mobile-head {
+	display: none;
+}
 
 
 .fixed_01 {
@@ -1070,6 +1073,7 @@ a.dont-show:hover {color:#FFF;}
         background: transparent;
     }
     #mobile-head {
+        display: block;
         background: #fff;
         width: 100%;
         height: 56px;

--- a/include/global_nav.php
+++ b/include/global_nav.php
@@ -1,4 +1,4 @@
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script>
 (function($) {
     $(function() {

--- a/index.html
+++ b/index.html
@@ -53,6 +53,11 @@
     })(window, document, 'script', 'dataLayer', 'GTM-WL2L4J');
   </script>
   <!-- End Google Tag Manager -->
+  <!-- brick -->
+  <script type="text/javascript" charset="UTF-8" src="//tag.brick.tools/js/brick.js"></script>
+  <script type="text/javascript" charset="UTF-8" src="//tag.brick.tools/js/prop/UA-9561304-10.js"></script>
+  <script>Brick.init();</script>
+  <!-- END brick -->
   <!-- <header> -->
   <?php include($_SERVER['DOCUMENT_ROOT'] . '/include/header.php'); ?>
   <!-- </header> -->


### PR DESCRIPTION
iPhone6s にて発生していたグロナビが開かないバグを修正
無料トライアルのヒートマップ分析ツール用タグをトップページに追加