### PR TITLE
Googleのリスティング強制停止したため、元凶の疑いがあるhttpsへのリダイレクトを停止。

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,11 +13,6 @@ RewriteEngine On
 RewriteCond %{HTTP_HOST} ^(www\.)?a-dreamlaw\.sakura\.ne\.jp$ [NC]
 RewriteRule .* http://a-dreamlaw.com%{REQUEST_URI} [R=301,L]
 
-RewriteEngine On
-
-RewriteCond %{ENV:HTTPS} !^on$
-RewriteCond %{HTTP:X-SAKURA-FORWARDED-FOR} ^$
-RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 
 Redirect 301 /business/divorce/type/separation.html /divorce/contents/separate.html
 


### PR DESCRIPTION
Googleのリスティング強制停止したため、元凶の疑いがあるhttpsへのリダイレクトを停止。